### PR TITLE
Add GHA workflow to validate build and update `docs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: Docs build and update
+
+on:
+  # Runs on push to master
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Upgrade pip
+        run: |
+          python3 -m pip install --upgrade pip
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: python3 -m pip install -r requirements.txt
+
+      - name: Build documentation
+        run: |
+          cd docsrc
+          make html
+
+      - name: Update documentation
+        run: cp -r docsrc/_build/html/* docs/
+
+      - uses: EndBug/add-and-commit@v7
+        with:
+          add: 'docs'
+          default_author: github_actor
+          message: 'Update docs'
+          signoff: true


### PR DESCRIPTION
## Description

This PR:

- Adds a GitHub Action to validate docs build
- Adds a step to update the changes made in `docsrc` over `docs` (Addresses the TODO [here](https://github.com/HarshCasper/cirun-docs#update-docs))